### PR TITLE
Ensure functions return properly

### DIFF
--- a/utils.R
+++ b/utils.R
@@ -53,6 +53,7 @@ getSISamples <- function (data, SIDist) {
   } else {
     return(NULL)
   }
+  return(samples)
 }
 
 
@@ -69,6 +70,7 @@ processSerialIntervalData <- function (serialIntervalData) {
   names <- c("EL", "ER", "SL", "SR", "type")
   colnames(serialIntervalData) <- names
   serialIntervalData <- as.data.frame(serialIntervalData)
+  return(serialIntervalData)
 }
 
 processIncidenceData <- function (incidenceData) {


### PR DESCRIPTION
Not sure why this wasn't happening already. 

I've not touched `processIncidenceData` since I handled that in #21 and don't want to cause merge conflicts. 