### PR TITLE
Remove default port of 3000

### DIFF
--- a/R/runApp.R
+++ b/R/runApp.R
@@ -1,8 +1,7 @@
 #' Runs EpiEstimApp
 #'
 #' This function runs EpiEstimApp
-#' @param port The port to run on. Defaults to 3000.
-#' @param ... Additional arguments
+#' @param ... Additional arguments (passed to shiny::runApp())
 #' @keywords run
 #' @export
 #' @examples
@@ -10,10 +9,10 @@
 #' runEpiEstimApp()
 #' }
 
-runEpiEstimApp <- function(port=3000, ...) {
+runEpiEstimApp <- function(...) {
   appDir <- system.file("app", package="EpiEstimApp")
   if (appDir == "") {
     stop("Could not find app directory. Try re-installing `EpiEstimApp`.", call. = FALSE)
   }
-  shiny::runApp(appDir, port=port, ...)
+  shiny::runApp(appDir, ...)
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -15,7 +15,7 @@ R_binary <- function () {
 # Start the server
 cat("Starting app\n")
 handle <- spawn_process(R_binary(), c('--no-save'))
-process_write(handle, "EpiEstimApp::runEpiEstimApp()\n")
+process_write(handle, "EpiEstimApp::runEpiEstimApp(port=3000)\n")
 cat("Waiting for app to start...\n")
 timeout <- 600
 t <- 0


### PR DESCRIPTION
Return to Shiny's default behaviour, and explicitly specify port 3000
for testing.
Closes #130