### PR TITLE
Ignore files created by twinkle during provisioning

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,5 @@
 ^\.Rproj\.user$
 ^\.travis\.yml$
 ^decision-tree-schematic\.pdf$
+^inst/app/.lib$
+^inst/app/.drat$


### PR DESCRIPTION
This PR will mean that files created during provisioning of the app will not be included in the package tarball - this is an issue with [twinkle](https://github.com/mrc-ide/twinkle) but I don't have time to sort that out at the moment.

Once merged could you please update the release branch too?