### PR TITLE
Fix bug where plots don't download

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: EpiEstimApp
 Title: EpiEstimApp: a package to add a graphical interface around EpiEstim,
     which is a package to estimate time varying reproduction numbers from
     epidemic curves
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: c(person("Jake", "Stockwin", email = "jstockwin@gmail.com", role = c("cre"), comment = c(ORCID = "0000-0001-7835-6603")),
     person("Anne", "Cori", role = "ctb", comment = c(ORCID = "0000-0002-8443-9162")),
     person("Zhian N.", "Kamvar", role = "ctb", comment = c(ORCID = "0000-0003-1458-7108"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,9 +23,9 @@ Remotes:
     annecori/EpiEstim,
     ropensci/RSelenium
 Suggests:
+    callr,
     testthat,
     RSelenium,
-    subprocess,
     compare
 License: GPL (>=2) | file LICENSE
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,15 @@
+# EpiEstimApp 1.0.1
+
+## Bug fixes
+* Fix a bug (#190) where plot would not save correctly (#191, @jstockwin)
+
 # EpiEstimApp 1.0.0
 
 ## Misc
-* Update authors list to include @annecori and @zkamvar (https://github.com/jstockwin/EpiEstimApp/pull/185)
+* Update authors list to include @annecori and @zkamvar (#185)
 
 ## Bug fixes
-* Stop writing files to protected folders (https://github.com/jstockwin/EpiEstimApp/pull/184)
+* Stop writing files to protected folders (#184)
 
 # EpiEstimApp 0.1.0
 

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -270,7 +270,7 @@ shiny::shinyServer(function(input, output, session) {
     }
   })
 
-  output$savePlot <- shiny::downloadHandler(
+  output$save_plot <- shiny::downloadHandler(
     filename = function() {"Plot.png"}, #nolint
     content = function(file) {
       if (!is.null(async_data$epi_estim_output)){

--- a/tests/testthat/testSuite002-states-testState1.1.R
+++ b/tests/testthat/testSuite002-states-testState1.1.R
@@ -47,7 +47,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState2.1.R
+++ b/tests/testthat/testSuite002-states-testState2.1.R
@@ -62,7 +62,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState2.2.R
+++ b/tests/testthat/testSuite002-states-testState2.2.R
@@ -92,7 +92,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState3.1.R
+++ b/tests/testthat/testSuite002-states-testState3.1.R
@@ -49,7 +49,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState4.1.R
+++ b/tests/testthat/testSuite002-states-testState4.1.R
@@ -46,7 +46,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState5.1.R
+++ b/tests/testthat/testSuite002-states-testState5.1.R
@@ -48,7 +48,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState6.1.R
+++ b/tests/testthat/testSuite002-states-testState6.1.R
@@ -51,7 +51,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState6.2.R
+++ b/tests/testthat/testSuite002-states-testState6.2.R
@@ -59,7 +59,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState7.1.R
+++ b/tests/testthat/testSuite002-states-testState7.1.R
@@ -52,7 +52,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState7.2.R
+++ b/tests/testthat/testSuite002-states-testState7.2.R
@@ -49,7 +49,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState7.3.R
+++ b/tests/testthat/testSuite002-states-testState7.3.R
@@ -111,7 +111,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState7.4.R
+++ b/tests/testthat/testSuite002-states-testState7.4.R
@@ -48,7 +48,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState7.5.R
+++ b/tests/testthat/testSuite002-states-testState7.5.R
@@ -42,7 +42,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState7.6.R
+++ b/tests/testthat/testSuite002-states-testState7.6.R
@@ -60,7 +60,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState8.1.R
+++ b/tests/testthat/testSuite002-states-testState8.1.R
@@ -83,7 +83,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState8.2.R
+++ b/tests/testthat/testSuite002-states-testState8.2.R
@@ -50,7 +50,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState8.3.R
+++ b/tests/testthat/testSuite002-states-testState8.3.R
@@ -58,7 +58,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },

--- a/tests/testthat/testSuite002-states-testState9.1.R
+++ b/tests/testthat/testSuite002-states-testState9.1.R
@@ -117,7 +117,7 @@ tryCatch({
   })
 
   test_that("no errors are displaying", {
-    expect_true(isDisplayed(remDr, pages$common$selectors$error_message))
+    expect_false(isDisplayed(remDr, pages$common$selectors$error_message))
     expect_equal(getText(remDr, pages$common$selectors$error_message), "")
   })
 },


### PR DESCRIPTION
This was because of a naming difference between `ui.R` and `server.R`
and probably happened during a refactor at some point...

Closes #190